### PR TITLE
feat: export IndicatorEffect

### DIFF
--- a/lib/smooth_page_indicator.dart
+++ b/lib/smooth_page_indicator.dart
@@ -2,6 +2,7 @@ library smooth_page_indicator;
 
 export 'src/effects/color_transition_effect.dart';
 export 'src/effects/expanding_dots_effect.dart';
+export 'src/effects/indicator_effect.dart';
 export 'src/effects/jumping_dot_effect.dart';
 export 'src/effects/scale_effect.dart';
 export 'src/effects/scrolling_dots_effect.dart';


### PR DESCRIPTION
This allows `IndicatorEffect` to be used as an interface in order to make the effects more interchangeable.