### PR TITLE
- Fix When the effect is less than zero, the final result is not corr…

### DIFF
--- a/lib/src/painters/expanding_dots_painter.dart
+++ b/lib/src/painters/expanding_dots_painter.dart
@@ -34,6 +34,11 @@ class ExpandingDotsPainter extends BasicIndicatorPainter {
         // ! Both a and b are non nullable
         color = Color.lerp(
             effect.activeDotColor, effect.dotColor, 1.0 - dotOffset)!;
+      } else if (i == count - 1 && offset < 0) {
+        width = effect.dotWidth + (effect.dotWidth - expansion);
+        // ! Both a and b are non nullable
+        color = Color.lerp(
+            effect.dotColor, effect.activeDotColor, 1.0 - dotOffset)!;
       }
       final yPos = size.height / 2;
       final rRect = RRect.fromLTRBR(


### PR DESCRIPTION
I found that the SmoothIndicator works correctly when the offset is greater than the current count, but the last dot is displayed incorrectly when the offset is less than zero.